### PR TITLE
Weirdness with twitter gem search

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -25,7 +25,8 @@ class TweetsController < ApplicationController
 
   def search
     @search_query = valid_params[:query]
-    @search_results = current_user.twitter_client.search(@search_query, {count: 20})
+    results = current_user.twitter_client.search(@search_query)
+    @search_results = results.to_h.fetch(:statuses).map { |t| Hashie::Mash.new(t) }
   end
 
   def reply


### PR DESCRIPTION
A SearchResult object seems to include the actual request within the
array of results so when you iterate over the array it just keeps
resending the API request. Fixed by using the t_h method to get the raw
hashes of tweet data and wrapping them in a Hashie so that the methods
are available to the view
